### PR TITLE
Add a method to resolve all registered instances of a type.

### DIFF
--- a/BoDi.Tests/BoDi.Tests.csproj
+++ b/BoDi.Tests/BoDi.Tests.csproj
@@ -72,6 +72,7 @@
     <Compile Include="RegisterTypeTests.cs" />
     <Compile Include="ResolveTests.cs" />
     <Compile Include="TestConfigSection.cs" />
+    <Compile Include="ResolveAllTests.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\BoDi\BoDi.csproj">

--- a/BoDi.Tests/ResolveAllTests.cs
+++ b/BoDi.Tests/ResolveAllTests.cs
@@ -1,0 +1,53 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using NUnit.Framework;
+
+namespace BoDi.Tests
+{
+
+    public interface IFancy{}
+    public class ImFancy : IFancy {}
+    public class ImFancier : IFancy {}
+    public class ImFanciest : IFancy {}
+
+    [TestFixture]
+    public class ResolveAllTests
+    {
+
+        [Test]
+        public void ShouldResolveTheRightNumberOfRegisteredTypes()
+        {
+            // given
+            var container = new ObjectContainer();
+            container.RegisterTypeAs<ImFancy, IFancy>("fancy");
+            container.RegisterTypeAs<ImFancier, IFancy>("fancier");
+            container.RegisterTypeAs<ImFanciest, IFancy>("fanciest");
+
+            // when
+            var results = container.ResolveAll<IFancy>();
+
+            // then
+            Assert.AreEqual(3, results.Count());
+        }
+
+        [Test]
+        public void ShouldResolveTheRightTypes()
+        {
+            // given
+            var container = new ObjectContainer();
+            container.RegisterTypeAs<ImFancy, IFancy>("fancy");
+            container.RegisterTypeAs<ImFancier, IFancy>("fancier");
+
+            // when
+            var results = container.ResolveAll<IFancy>();
+
+            // then
+            Assert.IsTrue(results.Contains(container.Resolve<IFancy>("fancy")));
+            Assert.IsTrue(results.Contains(container.Resolve<IFancy>("fancier")));
+        }
+
+    }
+
+}

--- a/BoDi/BoDi.cs
+++ b/BoDi/BoDi.cs
@@ -142,6 +142,13 @@ namespace BoDi
         ///     <para>The container pools the objects, so if the interface is resolved twice or the same type is registered for multiple interfaces, a single instance is created and returned.</para>
         /// </remarks>
         object Resolve(Type typeToResolve, string name = null);
+
+        /// <summary>
+        /// Resolves all implementations of an interface or type.
+        /// </summary>
+        /// <typeparam name="T">The interface or type.</typeparam>
+        /// <returns>An object implementing <typeparamref name="T"/>.</returns>
+        IEnumerable<T> ResolveAll<T>() where T : class;
     }
 
     public interface IContainedInstance
@@ -504,6 +511,13 @@ namespace BoDi
         public object Resolve(Type typeToResolve, string name = null)
         {
             return Resolve(typeToResolve, new ResolutionList(), name);
+        }
+
+        public IEnumerable<T> ResolveAll<T>() where T : class
+        {
+            return registrations
+                .Where(x => x.Key.Type == typeof(T))
+                .Select(x => Resolve (x.Key.Type, x.Key.Name) as T);
         }
 
         private object Resolve(Type typeToResolve, ResolutionList resolutionPath, string name)


### PR DESCRIPTION
Usage:

```c#
container.RegisterTypeAs<StringValueRetriever, IValueRetriever>("string");
container.RegisterTypeAs<BoolValueRetriever, IValueRetriever>("bool");
container.RegisterTypeAs<DateTimeValueRetriever, IValueRetriever>("datetime");

var retrievers = container.ResolveAll<IValueRetriever>();

// retrievers.Count() == 3
```