### PR TITLE
Expose the ObjectContainer.RegisterFactoryAs in the IObjectContainer interface

### DIFF
--- a/BoDi/BoDi.cs
+++ b/BoDi/BoDi.cs
@@ -118,6 +118,14 @@ namespace BoDi
         void RegisterInstanceAs(object instance, Type interfaceType, string name = null, bool dispose = false);
 
         /// <summary>
+        /// Registers an instance produced by <paramref name="factoryDelegate"/>. The delegate will be called only once and the instance it returned will be returned in each resolution.
+        /// </summary>
+        /// <typeparam name="TInterface">Interface to register as.</typeparam>
+        /// <param name="factoryDelegate">The function to run to obtain the instance.</param>
+        /// <param name="name">A name to resolve named instance, otherwise null.</param>
+        void RegisterFactoryAs<TInterface>(Func<IObjectContainer, TInterface> factoryDelegate, string name = null);
+
+        /// <summary>
         /// Resolves an implementation object for an interface or type.
         /// </summary>
         /// <typeparam name="T">The interface or type.</typeparam>


### PR DESCRIPTION
The test scenarios in our assembly can each depend on different class, and each is expensive to create (WebDriver with different browser types).

Without `RegisterFactoryAs`, all of them would need to be created, even if some of them aren't being used.

I'm aware of other workarounds, one to cast the container to `ObjectContainer`, another one to register a factory and refactor all test code to use it, but it sounds perfectly sensible to avoid all these costs and rather have this method exposed.

What do you guys think?