### PR TITLE
New instance per dependency strategy added for type registration

### DIFF
--- a/BoDi.Tests/RegisterFactoryDelegateTests.cs
+++ b/BoDi.Tests/RegisterFactoryDelegateTests.cs
@@ -122,5 +122,41 @@ namespace BoDi.Tests
             // when 
             Assert.Throws<ObjectContainerException>(() => container.Resolve<ClassWithCircularDependency1>(), "Circular dependency");
         }
+
+        [Test]
+        public void ShouldAlwaysCreateInstanceOnPerRequestStrategy()
+        {
+            // given
+
+            var container = new ObjectContainer();
+
+            // when 
+
+            container.RegisterFactoryAs<IInterface1>(() => new SimpleClassWithDefaultCtor()).InstancePerRequest();
+
+            // then
+
+            var obj1 = (SimpleClassWithDefaultCtor)container.Resolve<IInterface1>();
+            var obj2 = (SimpleClassWithDefaultCtor)container.Resolve<IInterface1>();
+            Assert.AreNotSame(obj1, obj2);
+        }
+
+        [Test]
+        public void ShouldAlwaysCreateSameObjectOnPerContextStrategy()
+        {
+            // given
+
+            var container = new ObjectContainer();
+
+            // when 
+
+            container.RegisterFactoryAs<IInterface1>(() => new SimpleClassWithDefaultCtor()).InstancePerContext();
+
+            // then
+
+            var obj1 = (SimpleClassWithDefaultCtor)container.Resolve<IInterface1>();
+            var obj2 = (SimpleClassWithDefaultCtor)container.Resolve<IInterface1>();
+            Assert.AreSame(obj1, obj2);
+        }
     }
 }

--- a/BoDi.Tests/RegisterFactoryDelegateTests.cs
+++ b/BoDi.Tests/RegisterFactoryDelegateTests.cs
@@ -132,7 +132,7 @@ namespace BoDi.Tests
 
             // when 
 
-            container.RegisterFactoryAs<IInterface1>(() => new SimpleClassWithDefaultCtor()).InstancePerRequest();
+            container.RegisterFactoryAs<IInterface1>(() => new SimpleClassWithDefaultCtor()).InstancePerDependency();
 
             // then
 

--- a/BoDi.Tests/RegisterTypeTests.cs
+++ b/BoDi.Tests/RegisterTypeTests.cs
@@ -122,7 +122,7 @@ namespace BoDi.Tests
 
             // when 
 
-            container.RegisterTypeAs<SimpleClassWithDefaultCtor, IInterface1>().InstancePerRequest();
+            container.RegisterTypeAs<SimpleClassWithDefaultCtor, IInterface1>().InstancePerDependency();
 
             // then
 

--- a/BoDi.Tests/RegisterTypeTests.cs
+++ b/BoDi.Tests/RegisterTypeTests.cs
@@ -112,5 +112,41 @@ namespace BoDi.Tests
             // then
             Assert.Catch<InvalidOperationException>(() => container.RegisterTypeAs(typeof(SimpleClassExtendingGenericInterface), typeof(IGenericInterface<>)));
         }
+
+        [Test]
+        public void ShouldAlwaysCreateInstanceOnPerRequestStrategy()
+        {
+            // given
+
+            var container = new ObjectContainer();
+
+            // when 
+
+            container.RegisterTypeAs<SimpleClassWithDefaultCtor, IInterface1>().InstancePerRequest();
+
+            // then
+
+            var obj1 = (SimpleClassWithDefaultCtor) container.Resolve<IInterface1>();
+            var obj2 = (SimpleClassWithDefaultCtor) container.Resolve<IInterface1>();
+            Assert.AreNotSame(obj1, obj2);
+        }
+
+        [Test]
+        public void ShouldAlwaysCreateSameObjectOnPerContextStrategy()
+        {
+            // given
+
+            var container = new ObjectContainer();
+
+            // when 
+
+            container.RegisterTypeAs<SimpleClassWithDefaultCtor, IInterface1>().InstancePerContext();
+
+            // then
+
+            var obj1 = (SimpleClassWithDefaultCtor)container.Resolve<IInterface1>();
+            var obj2 = (SimpleClassWithDefaultCtor)container.Resolve<IInterface1>();
+            Assert.AreSame(obj1, obj2);
+        }
     }
 }

--- a/BoDi/BoDi.cs
+++ b/BoDi/BoDi.cs
@@ -14,6 +14,7 @@
  * DEALINGS IN THE SOFTWARE.
  * 
  * Change history
+ *   - New 'instance per dependency' strategy added for type and factory registrations (by MKMZ)
  * 
  * vNext
  *   - Fix: Collection was modified issue (#7)
@@ -339,7 +340,7 @@ namespace BoDi
             object Resolve(ObjectContainer container, RegistrationKey keyToResolve, ResolutionList resolutionPath);
         }
 
-        private class TypeRegistration : RegistrationWithStrategy, IRegistration, IStrategyRegistration
+        private class TypeRegistration : RegistrationWithStrategy, IRegistration
         {
             private readonly Type implementationType;
 

--- a/BoDi/BoDi.cs
+++ b/BoDi/BoDi.cs
@@ -196,10 +196,10 @@ namespace BoDi
     public interface IStrategyRegistration
     {
         /// <summary>
-        /// Changes resolving strategy to a new instance per each request.
+        /// Changes resolving strategy to a new instance per each dependency.
         /// </summary>
         /// <returns></returns>
-        IStrategyRegistration InstancePerRequest();
+        IStrategyRegistration InstancePerDependency();
         /// <summary>
         /// Changes resolving strategy to a single instance per object container. This strategy is a default behaviour. 
         /// </summary>
@@ -331,7 +331,7 @@ namespace BoDi
         private enum SolvingStrategy
         {
             PerContext,
-            PerRequest
+            PerDependency
         }
 
         private interface IRegistration
@@ -367,7 +367,7 @@ namespace BoDi
                 return obj;
             }
 
-            protected override object ResolvePerRequest(ObjectContainer container, RegistrationKey keyToResolve, ResolutionList resolutionPath)
+            protected override object ResolvePerDependency(ObjectContainer container, RegistrationKey keyToResolve, ResolutionList resolutionPath)
             {
                 var typeToConstruct = GetTypeToConstruct(keyToResolve);
                 if (typeToConstruct.IsInterface)
@@ -427,19 +427,19 @@ namespace BoDi
             protected SolvingStrategy solvingStrategy = SolvingStrategy.PerContext;
             public virtual object Resolve(ObjectContainer container, RegistrationKey keyToResolve, ResolutionList resolutionPath)
             {
-                if (solvingStrategy == SolvingStrategy.PerRequest)
+                if (solvingStrategy == SolvingStrategy.PerDependency)
                 {
-                    return ResolvePerRequest(container, keyToResolve, resolutionPath);
+                    return ResolvePerDependency(container, keyToResolve, resolutionPath);
                 }
                 return ResolvePerContext(container, keyToResolve, resolutionPath);
             }
 
             protected abstract object ResolvePerContext(ObjectContainer container, RegistrationKey keyToResolve, ResolutionList resolutionPath);
-            protected abstract object ResolvePerRequest(ObjectContainer container, RegistrationKey keyToResolve, ResolutionList resolutionPath);
+            protected abstract object ResolvePerDependency(ObjectContainer container, RegistrationKey keyToResolve, ResolutionList resolutionPath);
 
-            public IStrategyRegistration InstancePerRequest()
+            public IStrategyRegistration InstancePerDependency()
             {
-                solvingStrategy = SolvingStrategy.PerRequest;
+                solvingStrategy = SolvingStrategy.PerDependency;
                 return this;
             }
 
@@ -468,7 +468,7 @@ namespace BoDi
                 }
                 return obj;
             }
-            protected override object ResolvePerRequest(ObjectContainer container, RegistrationKey keyToResolve, ResolutionList resolutionPath)
+            protected override object ResolvePerDependency(ObjectContainer container, RegistrationKey keyToResolve, ResolutionList resolutionPath)
             {
                 return container.InvokeFactoryDelegate(factoryDelegate, resolutionPath, keyToResolve);
             }

--- a/BoDi/BoDi.cs
+++ b/BoDi/BoDi.cs
@@ -89,6 +89,7 @@ namespace BoDi
         /// </summary>
         /// <typeparam name="TType">Implementation type</typeparam>
         /// <typeparam name="TInterface">Interface will be resolved</typeparam>
+        /// <returns>An object which allows to change resolving strategy.</returns>
         /// <param name="name">A name to register named instance, otherwise null.</param>
         /// <exception cref="ObjectContainerException">If there was already a resolve for the <typeparamref name="TInterface"/>.</exception>
         /// <remarks>
@@ -194,7 +195,15 @@ namespace BoDi
     }
     public interface ITypeRegistration
     {
+        /// <summary>
+        /// Changes resolving strategy to a new instance per each request.
+        /// </summary>
+        /// <returns></returns>
         ITypeRegistration InstancePerRequest();
+        /// <summary>
+        /// Changes resolving strategy to a single instance per object container. This strategy is a default behaviour. 
+        /// </summary>
+        /// <returns></returns>
         ITypeRegistration InstancePerContext();
     }
 


### PR DESCRIPTION
@gasparnagy 

BoDi currently does not allow to change a strategy of resolving objects. I am currently working on 2 projects that is using SpecFlow with BoDi and I have a problem when I was to have a class with isolated state. It is impossible without the disposal of current ObjectContainer and/or using a different IoC container.

I have added a new strategy which will create a new instance each time Resolve function is executed on ObjectCointainer.

### **Usage:**

```
container.RegisterTypeAs<SimpleClassWithDefaultCtor, IInterface1>().InstancePerDependency();

var obj1 = (SimpleClassWithDefaultCtor) container.Resolve<IInterface1>();
var obj2 = (SimpleClassWithDefaultCtor) container.Resolve<IInterface1>();
Assert.AreNotSame(obj1, obj2);
```