### PR TITLE
Exposing base container of object container to register global depend…

### DIFF
--- a/BoDi/BoDi.cs
+++ b/BoDi/BoDi.cs
@@ -456,7 +456,7 @@ namespace BoDi
         #endregion
 
         private bool isDisposed = false;
-        private readonly ObjectContainer baseContainer;
+        public ObjectContainer BaseContainer { get; }
         private readonly Dictionary<RegistrationKey, IRegistration> registrations = new Dictionary<RegistrationKey, IRegistration>();
         private readonly Dictionary<RegistrationKey, object> resolvedObjects = new Dictionary<RegistrationKey, object>();
         private readonly Dictionary<RegistrationKey, object> objectPool = new Dictionary<RegistrationKey, object>();
@@ -468,7 +468,7 @@ namespace BoDi
             if (baseContainer != null && !(baseContainer is ObjectContainer))
                 throw new ArgumentException("Base container must be an ObjectContainer", "baseContainer");
 
-            this.baseContainer = (ObjectContainer)baseContainer;
+            this.BaseContainer = (ObjectContainer)baseContainer;
             RegisterInstanceAs<IObjectContainer>(this);
         }
 
@@ -707,8 +707,8 @@ namespace BoDi
                 return new KeyValuePair<ObjectContainer, IRegistration>(this, registration);
             }
 
-            if (baseContainer != null)
-                return baseContainer.GetRegistrationResult(keyToResolve);
+            if (BaseContainer != null)
+                return BaseContainer.GetRegistrationResult(keyToResolve);
 
             if (IsSpecialNamedInstanceDictionaryKey(keyToResolve))
             {

--- a/BoDi/BoDi.cs
+++ b/BoDi/BoDi.cs
@@ -456,19 +456,20 @@ namespace BoDi
         #endregion
 
         private bool isDisposed = false;
-        public ObjectContainer BaseContainer { get; }
+        private readonly ObjectContainer baseContainer;
         private readonly Dictionary<RegistrationKey, IRegistration> registrations = new Dictionary<RegistrationKey, IRegistration>();
         private readonly Dictionary<RegistrationKey, object> resolvedObjects = new Dictionary<RegistrationKey, object>();
         private readonly Dictionary<RegistrationKey, object> objectPool = new Dictionary<RegistrationKey, object>();
 
         public event Action<object> ObjectCreated;
+        public IObjectContainer BaseContainer => baseContainer;
 
         public ObjectContainer(IObjectContainer baseContainer = null) 
         {
             if (baseContainer != null && !(baseContainer is ObjectContainer))
                 throw new ArgumentException("Base container must be an ObjectContainer", "baseContainer");
 
-            this.BaseContainer = (ObjectContainer)baseContainer;
+            this.baseContainer = (ObjectContainer)baseContainer;
             RegisterInstanceAs<IObjectContainer>(this);
         }
 
@@ -707,8 +708,8 @@ namespace BoDi
                 return new KeyValuePair<ObjectContainer, IRegistration>(this, registration);
             }
 
-            if (BaseContainer != null)
-                return BaseContainer.GetRegistrationResult(keyToResolve);
+            if (baseContainer != null)
+                return baseContainer.GetRegistrationResult(keyToResolve);
 
             if (IsSpecialNamedInstanceDictionaryKey(keyToResolve))
             {


### PR DESCRIPTION
This pull request exposes the base container of the BODI object container. This would allow registering dependencies in SpecFlow which span across multiple feature files. In our case this would be done through a runtime plugin event in the Specflow.Autofac plugin.

About two months ago I opened a PR which allows the registration of dependencies at a feature level. This PR was merged to SpecFlow and I have been successfully registering dependencies as single instances, shared across different scenarios in a feature file.

Now, I would like to start registering dependencies which can be shared as a single instance between multiple feature files. I tried using the events "CustomizeGlobalDependencies" and "CustomizeTestThreadDependencies" to register such dependencies. In order to locate the registration methods across all loaded assemblies, I am using the BindingRegistry to get all methods with a particular Attribute (similar to what is done for ScenarioDependencies in the Specflow.Autofac plugin). However, when the events "CustomizeGlobalDependencies" and "CustomizeTestThreadDependencies" are triggered, the property "Ready" of IBindingRegistry is set to false and the list of binding assemblies is not yet populated.

I proceeded by registering dependencies to the object container in the event "CustomizeFeatureDependencies", initiated an Autofac LifetimeScope named as "GlobalScope" and registered the scope with BODI's object container. Also, a check was added to ensure that global dependencies are registered only on the first trigger of "CustomizeFeatureDependencies". This was done using the IsRegistered method exposed by BODI. The problem with this approach is that an object container is created on every feature start, resulting in the IsRegistered to return false upon every call to "CustomizeFeatureDependencies", resulting in a new registration before every feature.

A solution to register the global dependencies and successfully locating the binding assemblies is to register the dependencies to the base container since the same base container is available on every call to "CustomizeFeatureDependencies". The submitted PR gives access to the base container so that I can access it from the object container during the "CustomizeFeatureDependencies" event.

I hope that this gives a good overview on the reason behind this PR. Should you not agree with this approach, please leave any other suggestions on how we can register dependencies as instances shared across different feature files.